### PR TITLE
data_port.data_value properties is obsolete. #16

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/OutPort.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/OutPort.java
@@ -308,15 +308,6 @@ public class OutPort<DataType> extends OutPortBase {
                    "Exception caught."+e.toString());
         }
 
-
-
-        addProperty("dataport.data_value", valueRef.v, cl); 
-
-        synchronized (m_profile.properties) {
-            NVListHolder nvholder = new NVListHolder(m_profile.properties);
-            m_propValueIndex = NVUtil.find_index(nvholder, 
-                                                 "dataport.data_value");
-        }
         this.addConnectorDataListener(ConnectorDataListenerType.ON_BUFFER_WRITE,
                                      new Timestamp<DataType>("on_write",cl));
         this.addConnectorDataListener(ConnectorDataListenerType.ON_SEND,
@@ -368,24 +359,6 @@ public class OutPort<DataType> extends OutPortBase {
             m_OnWrite.run(value);
             rtcout.println(Logbuf.TRACE, "OnWrite called");
         }
-
-        synchronized (m_profile_mutex) {
-            NVListHolder nvholder = 
-                 new NVListHolder(m_profile.properties);
-            try{
-                CORBA_SeqUtil.erase(nvholder, m_propValueIndex);
-             } catch (Exception ex) {
-                throw new InternalError("remove_organization_property()");
-            }
-
-            m_profile.properties = nvholder.value;
-            Class cl = value.getClass();
-            addProperty("dataport.data_value", value, cl);
-            nvholder.value = m_profile.properties;
-            m_propValueIndex = NVUtil.find_index(nvholder, "dataport.data_value");
-
-        }
-
 
         // 1) direct connection
         synchronized (m_directNewDataMutex){


### PR DESCRIPTION
Now the "data_port.data_value" in properties is obsolete. The related code in OutPort.java has been removed.

<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Now the "data_port.data_value" property value in PortProfile is obsolete from 1.2.0.
This can cause OutPort performance degradation, or crash the client if CORBA's maximum data size is exceeded.

## Description of the Change

The related code for the "data_port.data_value" property value in OutPort.java has been removed.

## Verification 

This change has been verified by creating a simple RTC.

- [x] Did you succeed the build?  
- [x] No warnings for the build?  

