### PR TITLE
Setting environment variable RTM_JAVA_ROOT

### DIFF
--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -92,6 +92,7 @@ install-arch:
 	# for openrtm-aist-java package
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
 	(cd $(CURDIR) ; cp -R jar $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
+	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=$(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > /etc/profile.d/openrtm-aist-java.sh)
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/bin)
 	(cd $(CURDIR) ; cp examples/rtcd_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcd_java)
 	(cd $(CURDIR) ; cp examples/rtcprof_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcprof_java)

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -92,7 +92,8 @@ install-arch:
 	# for openrtm-aist-java package
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
 	(cd $(CURDIR) ; cp -R jar $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
-	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=$(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > /etc/profile.d/openrtm-aist-java.sh)
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/etc/profile.d)
+	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > $(CURDIR)/debian/openrtm-aist-java/etc/profile.d/openrtm-aist-java.sh)
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/bin)
 	(cd $(CURDIR) ; cp examples/rtcd_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcd_java)
 	(cd $(CURDIR) ; cp examples/rtcprof_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcprof_java)


### PR DESCRIPTION
For #15, setting environment variable RTM_JAVA_ROOT in deb package.

## Identify the Bug

debパッケージインストール時にRTM_JAVA_ROOTを設定する必要がある。
パッケージインストール時に自動で設定されてほしい。


## Description of the Change

debパッケージ作成時に、/etc/profile.d/ 以下に、 openrtm-aist-java.sh として RTM_JAVA_ROOTを設定するスクリプトをインストールするようにする。


## Verification 

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
