### PR TITLE
Direct servant call for onExecute added. (1.2)

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/RTObjectStateMachine.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/RTObjectStateMachine.java
@@ -391,6 +391,14 @@ public class RTObjectStateMachine {
         {
             return; 
         }
+        // call Servant
+        if (m_rtobjPtr != null) {
+            if (m_rtobjPtr.on_execute(m_id) != ReturnCode_t.RTC_OK) {
+                m_sm.goTo(LifeCycleState.ERROR_STATE);
+            }
+            return;
+        }
+        // call Object reference
         if (!m_dfc) { 
             return; 
         }


### PR DESCRIPTION
Direct servant call for onExecute added.

## Identify the Bug

#25 の通り、onExecuteだけサーバントを直接呼ぶ処理が抜けており、オブジェクトリファレンス経由の呼び出しのみになっているためパフォーマンスが低下する可能性がある。

## Description of the Change

サーバントの直接呼出しを追加。

## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [x] Have you passed the unit tests?  
