### PR TITLE
1つのポートに2本以上のコネクタを生成できないバグの修正

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/PortBase.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/PortBase.java
@@ -744,7 +744,7 @@ public abstract class PortBase extends PortServicePOA {
             "YES","NO",default_value)){
             for(int ic=0;ic<connector_profile.value.ports.length;++ic){
                 RTC.PortService port = connector_profile.value.ports[ic];
-                if(port._is_equivalent(m_objref)){
+                if(!port._is_equivalent(m_objref)){
                     boolean ret = CORBA_RTCUtil.already_connected(port, 
                                                                   m_objref);
                     if(ret){


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

https://github.com/OpenRTM/OpenRTM-aist/issues/425

## Description of the Change

条件分岐で論理否定演算子を付け忘れるという単純なミスだったので修正した。
実装時にどんな動作確認をしたのか非常に疑問。


## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
