### PR TITLE
already_connected関数に同一のポートを2個指定した場合にfalseを返すようにする

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/util/CORBA_RTCUtil.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/util/CORBA_RTCUtil.java
@@ -1182,6 +1182,9 @@ public class CORBA_RTCUtil {
      */
     public static boolean already_connected(PortService localport, 
             PortService otherport){
+        if(localport._is_equivalent(otherport)){
+            return false;
+        }
         ConnectorProfileListHolder conprof =
                 new ConnectorProfileListHolder();
         conprof.value = localport.get_connector_profiles();


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug
## Description of the Change

以下と同じ

- https://github.com/OpenRTM/OpenRTM-aist/pull/428



## Verification 

Verify that the change has not introduced any regressions.   
Check the item below and fill the checbox.  
You can fill checbox by using the [X].  
if this request do not need to build and tests, delete the items and specify that these are no need.  

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  全く動作確認していません。
