### PR TITLE
OpenRTM-aist-Java 1.2 の修正をsvn/RELENG_1_2ブランチへマージする

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/OutPort.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/OutPort.java
@@ -307,16 +307,6 @@ public class OutPort<DataType> extends OutPortBase {
             rtcout.println(Logbuf.WARN, 
                    "Exception caught."+e.toString());
         }
-
-
-
-        addProperty("dataport.data_value", valueRef.v, cl); 
-
-        synchronized (m_profile.properties) {
-            NVListHolder nvholder = new NVListHolder(m_profile.properties);
-            m_propValueIndex = NVUtil.find_index(nvholder, 
-                                                 "dataport.data_value");
-        }
     }
     
     /**
@@ -363,24 +353,6 @@ public class OutPort<DataType> extends OutPortBase {
             m_OnWrite.run(value);
             rtcout.println(Logbuf.TRACE, "OnWrite called");
         }
-
-        synchronized (m_profile_mutex) {
-            NVListHolder nvholder = 
-                 new NVListHolder(m_profile.properties);
-            try{
-                CORBA_SeqUtil.erase(nvholder, m_propValueIndex);
-             } catch (Exception ex) {
-                throw new InternalError("remove_organization_property()");
-            }
-
-            m_profile.properties = nvholder.value;
-            Class cl = value.getClass();
-            addProperty("dataport.data_value", value, cl);
-            nvholder.value = m_profile.properties;
-            m_propValueIndex = NVUtil.find_index(nvholder, "dataport.data_value");
-
-        }
-
 
         // 1) direct connection
         synchronized (m_directNewDataMutex){

--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/util/NVUtil.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/util/NVUtil.java
@@ -179,12 +179,7 @@ public class NVUtil {
             try {
                 Any anyVal = nvlist.value[intIdx].value;
                 String value = null;
-                if( anyVal.type().kind() == TCKind.tk_wstring ) {
-                    //value = anyVal.extract_wstring();
-                    continue; 
-                } else if( anyVal.type().kind() == TCKind.tk_string ) {
-                    value = anyVal.extract_string();
-                } else if( anyVal.type().kind() == TCKind.tk_objref ) {
+                if( anyVal.type().kind() == TCKind.tk_objref ) {
 		    org.omg.CORBA.Object obj = anyVal.extract_Object();
 		    if (obj != null) {
 			value = obj.toString();
@@ -192,73 +187,110 @@ public class NVUtil {
 		    else {
 			value = "";
 		    }
-                } else if( anyVal.type().kind() == TCKind.tk_char ) {
-		    value =  Character.toString(anyVal.extract_char());
-                } else if( anyVal.type().kind() == TCKind.tk_double ) {
-		    value =  Double.toString(anyVal.extract_double());
-                } else if( anyVal.type().kind() == TCKind.tk_float ) {
-		    value =  Float.toString(anyVal.extract_float());
-                } else if( anyVal.type().kind() == TCKind.tk_long ) {
-		    value =  Integer.toString(anyVal.extract_long());
-                } else if( anyVal.type().kind() == TCKind.tk_longlong ) {
-		    value =  Long.toString(anyVal.extract_longlong());
+			
+                } else if( anyVal.type().kind() == TCKind.tk_boolean ) {
+                    value =  anyVal.extract_boolean() ? "true" : "false";
                 } else if( anyVal.type().kind() == TCKind.tk_octet ) {
-		    value =  Byte.toString(anyVal.extract_octet());
+                    value =  Byte.toString(anyVal.extract_octet());
+                } else if( anyVal.type().kind() == TCKind.tk_char ) {
+                    value =  Character.toString(anyVal.extract_char());
+                } else if( anyVal.type().kind() == TCKind.tk_wchar ) {
+                    value =  Character.toString(anyVal.extract_wchar());
+                } else if( anyVal.type().kind() == TCKind.tk_string ) {
+                    value = anyVal.extract_string();
+                } else if( anyVal.type().kind() == TCKind.tk_wstring ) {
+                    value = anyVal.extract_wstring();
+                } else if( anyVal.type().kind() == TCKind.tk_short ) {
+                    value =  Integer.toString(anyVal.extract_short());
+                } else if( anyVal.type().kind() == TCKind.tk_ushort ) {
+                    value =  Integer.toString(anyVal.extract_ushort());
+                } else if( anyVal.type().kind() == TCKind.tk_long ) {
+                    value =  Integer.toString(anyVal.extract_long());
+                } else if( anyVal.type().kind() == TCKind.tk_ulong ) {
+                    value =  Integer.toString(anyVal.extract_ulong());
+                } else if( anyVal.type().kind() == TCKind.tk_longlong ) {
+                    value =  Long.toString(anyVal.extract_longlong());
+                } else if( anyVal.type().kind() == TCKind.tk_ulonglong ) {
+                    value =  Long.toString(anyVal.extract_ulonglong());
+                } else if( anyVal.type().kind() == TCKind.tk_fixed ) {
+                    value = anyVal.extract_fixed().toString();
+                } else if( anyVal.type().kind() == TCKind.tk_float ) {
+                    value =  Float.toString(anyVal.extract_float());
+                } else if( anyVal.type().kind() == TCKind.tk_double ) {
+                    value =  Double.toString(anyVal.extract_double());
                 } else if( anyVal.type().kind() == TCKind.tk_struct ) {
 
-                    if(anyVal.type().name().equals("TimedLong")) {
-                        value = RTC.TimedLongHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedBoolean")) {
+                    if(anyVal.type().name().equals("TimedBoolean")) {
                         value = RTC.TimedBooleanHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedChar")) {
-                        value = RTC.TimedCharHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedDouble")) {
-                        value = RTC.TimedDoubleHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedFloat")) {
-                        value = RTC.TimedFloatHelper.extract(anyVal).toString();
                     }
                     else if(anyVal.type().name().equals("TimedOctet")) {
                         value = RTC.TimedOctetHelper.extract(anyVal).toString();
                     }
+                    else if(anyVal.type().name().equals("TimedChar")) {
+                        value = RTC.TimedCharHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedWChar")) {
+                        value = RTC.TimedCharHelper.extract(anyVal).toString();
+                    }
                     else if(anyVal.type().name().equals("TimedShort")) {
                         value = RTC.TimedShortHelper.extract(anyVal).toString();
                     }
+                    else if(anyVal.type().name().equals("TimedUShort")) {
+                        value = RTC.TimedShortHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedLong")) {
+                        value = RTC.TimedLongHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedULong")) {
+                        value = RTC.TimedLongHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedFloat")) {
+                        value = RTC.TimedFloatHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedDouble")) {
+                        value = RTC.TimedDoubleHelper.extract(anyVal).toString();
+                    }
                     else if(anyVal.type().name().equals("TimedString")) {
+                        value = RTC.TimedStringHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedWString")) {
                         value = RTC.TimedStringHelper.extract(anyVal).toString();
                     }
                     else if(anyVal.type().name().equals("TimedBooleanSeq")) {
                         value = RTC.TimedBooleanSeqHelper.extract(anyVal).toString();
                     }
-                    else if(anyVal.type().name().equals("TimedCharSeq")) {
-                        value = RTC.TimedCharSeqHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedDoubleSeq")) {
-                        value = RTC.TimedDoubleSeqHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedFloatSeq")) {
-                        value = RTC.TimedFloatSeqHelper.extract(anyVal).toString();
-                    }
-                    else if(anyVal.type().name().equals("TimedLongSeq")) {
-                        value = RTC.TimedLongSeqHelper.extract(anyVal).toString();
-                    }
                     else if(anyVal.type().name().equals("TimedOctetSeq")) {
                         value = RTC.TimedOctetSeqHelper.extract(anyVal).toString();
                     }
-                    else if(anyVal.type().name().equals("TimedShortSeq")) {
-                        value = RTC.TimedShortSeqHelper.extract(anyVal).toString();
+                    else if(anyVal.type().name().equals("TimedCharSeq")) {
+                        value = RTC.TimedCharSeqHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedWCharSeq")) {
+                        value = RTC.TimedCharSeqHelper.extract(anyVal).toString();
                     }
                     else if(anyVal.type().name().equals("TimedStringSeq")) {
                         value = RTC.TimedStringSeqHelper.extract(anyVal).toString();
                     }
-                    else if(anyVal.type().name().equals("TimedULongSeq")) {
-                        value = RTC.TimedULongSeqHelper.extract(anyVal).toString();
+                    else if(anyVal.type().name().equals("TimedWStringSeq")) {
+                        value = RTC.TimedWStringSeqHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedShortSeq")) {
+                        value = RTC.TimedShortSeqHelper.extract(anyVal).toString();
                     }
                     else if(anyVal.type().name().equals("TimedUShortSeq")) {
                         value = RTC.TimedUShortSeqHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedLongSeq")) {
+                        value = RTC.TimedLongSeqHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedULongSeq")) {
+                        value = RTC.TimedULongSeqHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedFloatSeq")) {
+                        value = RTC.TimedFloatSeqHelper.extract(anyVal).toString();
+                    }
+                    else if(anyVal.type().name().equals("TimedDoubleSeq")) {
+                        value = RTC.TimedDoubleSeqHelper.extract(anyVal).toString();
                     }
                     else {
                         try {

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -92,6 +92,7 @@ install-arch:
 	# for openrtm-aist-java package
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
 	(cd $(CURDIR) ; cp -R jar $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
+	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=$(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > /etc/profile.d/openrtm-aist-java.sh)
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/bin)
 	(cd $(CURDIR) ; cp examples/rtcd_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcd_java)
 	(cd $(CURDIR) ; cp examples/rtcprof_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcprof_java)

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -92,7 +92,8 @@ install-arch:
 	# for openrtm-aist-java package
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
 	(cd $(CURDIR) ; cp -R jar $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
-	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=$(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > /etc/profile.d/openrtm-aist-java.sh)
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/etc/profile.d)
+	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > $(CURDIR)/debian/openrtm-aist-java/etc/profile.d/openrtm-aist-java.sh)
 	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/bin)
 	(cd $(CURDIR) ; cp examples/rtcd_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcd_java)
 	(cd $(CURDIR) ; cp examples/rtcprof_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcprof_java)


### PR DESCRIPTION
close #40 

## Identify the Bug

Link #40 

- masterブランチへのコミットを、cherry-pickでsvn/RELENG_1_2へ反映させた
- マージする修正コミットのIDは以下の通り（コミット順）
  - #16 : 10b4cb7
  - #18 : caa9fee
  - #15 : 0eb6933 3e5bd65

```
git cherry-pick 10b4cb7 caa9fee 0eb6933 3e5bd65
```

## Description of the Change

- 10b4cb7 の実行時、コンフリクトが発生。 masterブランチにのみ入っている「FSM4RTC」に関する処理を指摘されたので、この部分を削除してsvn/RELENG_1_2へ反映させた
- 修正ファイル：jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/OutPort.java
- 削除した部分： 5e9eab5 で追加された下記★の処理
```
vim jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/OutPort.java
311 <<<<<<< HEAD
312
313
314         addProperty("dataport.data_value", valueRef.v, cl);
315
316         synchronized (m_profile.properties) {
317             NVListHolder nvholder = new NVListHolder(m_profile.properties);
318             m_propValueIndex = NVUtil.find_index(nvholder,
319                                                  "dataport.data_value");
320         }
321 =======
★以下の処理を削除★
322         this.addConnectorDataListener(ConnectorDataListenerType.ON_BUFFER_WRITE,
323                                      new Timestamp<DataType>("on_write",cl));
324         this.addConnectorDataListener(ConnectorDataListenerType.ON_SEND,
325                                      new Timestamp<DataType>("on_send",cl));
326
327 >>>>>>> 10b4cb7... data_port.data_value properties is obsolete. #16
```

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- debパッケージ作成動作を確認