### PR TITLE
Travis環境でビルドが通るようにyamlファイルを改善する(1.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 dist: xenial
 language: java
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
+sudo: false
+dist: xenial
 language: java
 
-sudo: required
+addons:
+  apt:
+    packages:
+    - ant
 
 jdk:
-  - oraclejdk8
+#  - oraclejdk8
   - openjdk8
-
-env:
-  - TARGET_DIST=ubuntu TARGET_VER=1804
-  - TARGET_DIST=ubuntu TARGET_VER=1604
-  - TARGET_DIST=debian TARGET_VER=8
 
 script:
   - bash buildRTC.sh


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link #42 

- Travis CI の trusty 環境はデフォルトで ant がインストールされていたが、xenial 環境はymlファイルでのインストール指定が必要となったので追加した
https://docs.travis-ci.com/user/languages/java/

- sudo でインストールする処理が含まれないので、「sudo: required」を削除した
- 関連して「sudo: false」を指定すると処理が早くなるという情報を元に追加したが、最近の公式のポストで指定しない方がよいとあったので、追加しないことにした
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

- docker を利用していないので、env設定を削除した

- oraclejdk8は、Travis CI の trusty 環境では利用できたが、xenial 環境は利用できなくなった
  - 下記情報によると、xenial環境にプレインストールされなくなり、oracleから取得することもできなくなるとあったので、設定を外した
https://github.com/travis-ci/travis-ci/issues/10290


## Verification 

- [x] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- 自分のGitHubリポジトリのmasterブランチに同じtravis.ymlを配置し、Travis CIでビルドが通ることを確認した