### PR TITLE
JavaのソースとJarファイルパッケージ名からRELEASEの文字を外す

### DIFF
--- a/jp.go.aist.rtm.RTC/build.xml
+++ b/jp.go.aist.rtm.RTC/build.xml
@@ -749,7 +749,7 @@
 
 		<mkdir dir="${dist.dir}/source/OpenRTM-aist-Java-${version}" />
 
-		<delete file="${dist.dir}/source/OpenRTM-aist-Java-${version}-RELEASE.zip" />
+		<delete file="${dist.dir}/source/OpenRTM-aist-Java-${version}.zip" />
 
 		<copy todir="${dist.dir}/source/OpenRTM-aist-Java-${version}/src" >
 
@@ -775,13 +775,13 @@
 
 		<copy file=".classpath" todir="${dist.dir}/source/OpenRTM-aist-Java-${version}" />
 
-		<zip destfile="${dist.dir}/source/OpenRTM-aist-Java-${version}-RELEASE.zip" basedir="${dist.dir}/source/OpenRTM-aist-Java-${version}" />
+		<zip destfile="${dist.dir}/source/OpenRTM-aist-Java-${version}.zip" basedir="${dist.dir}/source/OpenRTM-aist-Java-${version}" />
 
 		<delete dir="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar/OpenRTM-aist/${short_ver}" />
 
 		<mkdir dir="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar/OpenRTM-aist/${short_ver}" />
 
-		<delete file="${dist.dir}/source/OpenRTM-aist-Java-${version}-RELEASE-jar.zip" />
+		<delete file="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar.zip" />
 
 		<copy todir="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar/OpenRTM-aist/${short_ver}/jar" >
 
@@ -846,11 +846,11 @@
 
 		</copy>
 
-		<zip destfile="${dist.dir}/source/OpenRTM-aist-Java-${version}-RELEASE-jar.zip" basedir="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar" />
+		<zip destfile="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar.zip" basedir="${dist.dir}/source/OpenRTM-aist-Java-${version}-jar" />
 
-		<delete file="${dist.dir}/source/OpenRTM-aist-Java-${version}-RELEASE.tar.gz" />
+		<delete file="${dist.dir}/source/OpenRTM-aist-Java-${version}.tar.gz" />
 
-		<tar destfile="${dist.dir}/source/OpenRTM-aist-Java-${version}-RELEASE.tar.gz" 
+		<tar destfile="${dist.dir}/source/OpenRTM-aist-Java-${version}.tar.gz" 
 			basedir="../../" 
 			compression="gzip" 
 			excludes="OpenRTM-aist-Java/jp.go.aist.rtm.RTC/jcoverage.ser, 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link #46 

- ソースとJarファイルパッケージ名から「RELEASE」の文字を外す
- この修正により、svn/RELENG_1_2 ソースで作成したパッケージ名は下記となる
    OpenRTM-aist-Java-1.2.1-jar.zip
    OpenRTM-aist-Java-1.2.1.tar.gz
    OpenRTM-aist-Java-1.2.1.zip

## Verification 

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- buildPackage.sh スクリプト実行で、上記パッケージファイル作成動作を確認