### PR TITLE
Fixed to include Img and JARA_ARM in OpenRTM jar file.

### DIFF
--- a/jp.go.aist.rtm.RTC/build.xml
+++ b/jp.go.aist.rtm.RTC/build.xml
@@ -21,6 +21,8 @@
 	<property name="source.rtmtemp" value="src/RTMTemp"/>
 
 	<property name="source.openrtm" value="src/OpenRTM"/>
+	<property name="source.img" value="src/Img"/>
+	<property name="source.jaraarm" value="src/JARA_ARM"/>
 
 	<property name="source.openrtmtemp" value="src/OpenRTMTemp"/>
 
@@ -428,7 +430,7 @@
 
 	<target name="compile" description="ソースをコンパイルします(Linux)">
 		<mkdir dir="${build.dir}" />
-		<javac srcdir="${source.sdo}:${source.rtc}:${source.rtm}:${source.openrtm}" destdir="${build.dir}" classpath="lib/commons-cli-1.1.jar:lib/jna-4.2.2.jar:lib/jna-platform-4.2.2.jar" encoding="UTF-8" />
+		<javac srcdir="${source.sdo}:${source.rtc}:${source.rtm}:${source.openrtm}:${source.img}:${source.jaraarm}" destdir="${build.dir}" classpath="lib/commons-cli-1.1.jar:lib/jna-4.2.2.jar:lib/jna-platform-4.2.2.jar" encoding="UTF-8" />
 		<javac srcdir="${source.main}" destdir="${build.dir}" classpath="lib/commons-cli-1.1.jar:lib/jna-4.2.2.jar:lib/jna-platform-4.2.2.jar"  encoding="UTF-8" includes="go/aist/**" excludes="go/aist/ForSunOrb/**,go/aist/ForJacOrb/**"/>
 		<javac srcdir="${source.rtcd}:${source.rtcprof}" destdir="${build.dir}" classpath="lib/commons-cli-1.1.jar:lib/jna-4.2.2.jar:lib/jna-platform-4.2.2.jar"  encoding="UTF-8"/>
 		<javac srcdir="${source.extension}:" destdir="${build.dir}" classpath="lib/commons-cli-1.1.jar:lib/jna-4.2.2.jar:lib/jna-platform-4.2.2.jar"  encoding="UTF-8" />


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

Link to #54 


## Description of the Change

- CameraCommonInterface.idl、ManipulatorCommonInterface_*.idl をIDLコンパイルしていたが、
ソースコンパイルの対象に指定していなかったため、classファイルが生成されなかった
- この結果 OpenRTM-aist-Java-1.2.1-jar.zip に含まれず、これから作成したLinux用パッケージやWindows用マージモジュールにも含まれないことになっていた

## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
- 修正ソースからUbuntu18.04用debパッケージを作成し、これでインストールした環境でImg::TimedCameraImage型とJARA_ARM::ManipulatorCommonInterface_Middle型を使っているRTCの新規作成・起動動作を確認した