### PR TITLE
jar file loadpath issue

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/ModuleManager.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/ModuleManager.java
@@ -922,7 +922,7 @@ public class ModuleManager {
      * {@.en This class is used to filter directory listings 
      * in the list method of class File.}
      */
-    private class FilePathFilter implements FilenameFilter{
+    private class FilePathFilter implements FilenameFilter {
         private String m_regex = new String();
         public FilePathFilter(String str) {
             m_regex = str;
@@ -1290,8 +1290,6 @@ public class ModuleManager {
             return false;
         }
     }
-    private Logbuf rtcout;
-    private ArrayList<Properties> m_modprofs = new ArrayList<Properties>();
     /**
      * {@.ja 指定したパス以下に存在するディレクトリを探索する}
      * {@.en Searches the directory which exists in below of designated paths.}
@@ -1326,5 +1324,9 @@ public class ModuleManager {
         }
         return result;
     }
-
+    /**
+     * private variables
+     */
+    private Logbuf rtcout;
+    private ArrayList<Properties> m_modprofs = new ArrayList<Properties>();
 }


### PR DESCRIPTION
jar file loadpath issue
https://openrtm.org/openrtm/ja/content/openrtm-users-02802-java%E7%89%88%E3%81%AErtcd%E3%81%AE%E5%8B%95%E4%BD%9C%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6

## Identify the Bug

カレントディレクトリでrtcdを起動する場合，
ディレクトリ内に，
- rtc - ConsoleOut.dll
- ConsoleIn.dll
- conf - rtc.conf
のように配置されている場合，
manager.modules.load_path : rtc
manager.modules.preload : ConsoleIn.dll, ConsoleOut.dll
manager.components.precreate : ConsoleIn, ConsoleOut
のように設定するのが定石と考えていますが，
現状のJava版では，相対パスをパッケージ名と解釈するコードがある

## Description of the Change

manager.modules.preloadに設定されたものが
jarファイルの場合に，RTCのクラス名がデフォルトパッケージにある，という前提を元に，
jarをURLClassLoaderで開き，クラス名からClass型オブジェクトを生成

### 前提条件

Javaで jarファイル内の特定のクラスをロードするおよびエントリーポイント関数を呼び出す場合は以下の条件・情報が必要

- jarファイルがCLASSPATH配下になければいけない
- ロードするクラスのクラス名が必要
  - 通常classファイルはクラス名
  - jarファイルはそうとは限らない
- ロードするクラスのパッケージ名が必要
  - パッケージ名は作成する人が任意につけることができる。
  - RTCBuilderで生成すると無名パッケージ名となる。
  - 一方、ConsoleIn, ConsoleOutはRTMExample.SimpleIO というパッケージ名が設定されている
- ロードするクラスの特定のエントリポイントの関数名が必要
  - RTCのエントリポイントは registerModle()
  -  

### rtc.conf での指定方法について検討

例えば以下のように指定できるようにする。

```rtc.conf 
# ↓この下にjarやclassがいろいろ入っている
manager.modules.load_path: /usr/share/openrtm-2.0/components/java, /home/work, /home/openrtm/katkin_ws

# ConsoleIn ConsoleOut.class→ classのRTC指定
# jarの指定→以下のようにjarファイルを指定技ごカッコ()内でパッケージ名・クラス名・初期化関数名を指定
# → この方法は他の言語との互換性も一応ある（他言語はカッコ内は初期化関数のみ)
# <module_name>(.<extention>) (package_names..class_name::init_func_name), ...
manager.modules.preload: ConsoleIn, ConsoleOut.class, SeqIn.jar (RTMExxamples.SeqIO.SequenceIn:myRegisterModule)
```
## Verification 

- [ ] Did you succeed the build?  
- [ ] No warnings for the build?  
- [ ] Have you passed the unit tests?  
