### PR TITLE
openrtm2-javaのdebパッケージ作成に関する修正

### DIFF
--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/Manager.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/Manager.java
@@ -2923,9 +2923,9 @@ public class Manager {
                                                         "enable", "disable", false));
 
             rtcout.println(Logbuf.INFO, m_config.getProperty("openrtm.version"));
-            rtcout.println(Logbuf.INFO, "Copyright (C) 2003-2020, Noriaki Ando and OpenRTM development team,");
+            rtcout.println(Logbuf.INFO, "Copyright (C) 2003-2022, Noriaki Ando and OpenRTM development team,");
             rtcout.println(Logbuf.INFO, "  Intelligent Systems Research Institute, AIST,");
-            rtcout.println(Logbuf.INFO, "Copyright (C) 2020, Noriaki Ando and OpenRTM development team,");
+            rtcout.println(Logbuf.INFO, "Copyright (C) 2022, Noriaki Ando and OpenRTM development team,");
             rtcout.println(Logbuf.INFO, "  Industrial Cyber-Physical Research Center, AIST,");
             rtcout.println(Logbuf.INFO, "  All right reserved.");
             rtcout.println(Logbuf.INFO, "Manager starting.");

--- a/packages/deb/debian/changelog
+++ b/packages/deb/debian/changelog
@@ -1,14 +1,8 @@
-openrtm-aist-java (2.0.0-0) experimental; urgency=low
+openrtm2-java (2.0.0-0) experimental; urgency=low
 
   * 2.0.0-0 (2.0.0-RELEASE). OpenRTM-aist-2.0.0-RELEASE
 
  -- Noriaki Ando <n-ando@aist.go.jp>  Tue, 28 May 2019 15:57:54 +0900
-
-openrtm-aist-java (1.2.0-0) experimental; urgency=low
-
-  * 1.2.0-0 (1.2.0-RELEASE). OpenRTM-aist-1.2.0-RELEASE
-
- -- Noriaki Ando <n-ando@aist.go.jp>  Mon, 12 Dec 2016 18:36:29 +0900
 
 
 

--- a/packages/deb/debian/control
+++ b/packages/deb/debian/control
@@ -1,4 +1,4 @@
-Source: openrtm-aist-java
+Source: openrtm2-java
 Section: science
 Priority: extra
 Maintainer: Noriaki Ando <n-ando@aist.go.jp>
@@ -6,11 +6,11 @@ Build-Depends: debhelper
 Standards-Version: 3.8.4
 Homepage: http://openrtm.org
 
-Package: openrtm-aist-java
+Package: openrtm2-java
 Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, default-jdk|openjdk-7-jdk|openjdk-8-jdk, openrtm-aist-dev
+Depends: ${shlibs:Depends}, ${misc:Depends}, openjdk-8-jdk, openrtm2-dev
 Description: OpenRTM-aist, RT-Middleware distributed by AIST
  OpenRTM-aist is a reference implementation of RTC (Robotic Technology
  Component Version 1.1, formal/12-09-01) specification which is OMG
@@ -22,14 +22,14 @@ Description: OpenRTM-aist, RT-Middleware distributed by AIST
  National Institute of Advanced Industrial Science and Technology
  (AIST), Japan. Please see http://www.openrtm.org/ for more detail.
 
-Package: openrtm-aist-java-example
+Package: openrtm2-java-example
 Architecture: any
 Multi-Arch: same
-Depends: openrtm-aist
+Depends: openrtm2
 Description: OpenRTM-aist-Java examples
  Example components and sources of OpenRTM-aist.
 
-Package: openrtm-aist-java-doc
+Package: openrtm2-java-doc
 Architecture: all
 Description: Documentation for openrtm-aist-java
  Class reference manual of OpenRTM-aist.

--- a/packages/deb/debian/copyright
+++ b/packages/deb/debian/copyright
@@ -9,7 +9,7 @@ Upstream Author(s):
 
 Copyright: 
 
-    Copyright (C) 2003-2017
+    Copyright (C) 2003-2022
     Noriaki Ando and the OpenRTM-aist Project team
     National Institute of Advanced Industrial Science and Technology (AIST),
     Tsukuba, Japan, All rights reserved.

--- a/packages/deb/debian/rules
+++ b/packages/deb/debian/rules
@@ -77,9 +77,9 @@ install-indep:
 	dh_installdirs -i
 
 	# for openrtm-aist-java-doc package
-	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java-doc/usr/share/openrtm-$(SHORT_VER)/doc/java)
-	(cd $(CURDIR) ; cp -R JavaDoc $(CURDIR)/debian/openrtm-aist-java-doc/usr/share/openrtm-$(SHORT_VER)/doc/java)
-	(cd $(CURDIR) ; cp -R JavaDocEn $(CURDIR)/debian/openrtm-aist-java-doc/usr/share/openrtm-$(SHORT_VER)/doc/java)
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm2-java-doc/usr/share/openrtm-$(SHORT_VER)/doc/java)
+	(cd $(CURDIR) ; cp -R JavaDoc $(CURDIR)/debian/openrtm2-java-doc/usr/share/openrtm-$(SHORT_VER)/doc/java)
+	(cd $(CURDIR) ; cp -R JavaDocEn $(CURDIR)/debian/openrtm2-java-doc/usr/share/openrtm-$(SHORT_VER)/doc/java)
 	
 	dh_install -i
 
@@ -90,23 +90,23 @@ install-arch:
 	dh_installdirs -s
 
 	# for openrtm-aist-java package
-	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
-	(cd $(CURDIR) ; cp -R jar $(CURDIR)/debian/openrtm-aist-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
-	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/etc/profile.d)
-	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > $(CURDIR)/debian/openrtm-aist-java/etc/profile.d/openrtm-aist-java.sh)
-	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java/usr/bin)
-	(cd $(CURDIR) ; cp examples/rtcd_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcd_java)
-	(cd $(CURDIR) ; cp examples/rtcprof_java $(CURDIR)/debian/openrtm-aist-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm-aist-java/usr/bin/rtcprof_java)
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm2-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
+	(cd $(CURDIR) ; cp -R jar $(CURDIR)/debian/openrtm2-java/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER))
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm2-java/etc/profile.d)
+	(cd $(CURDIR) ; echo "export RTM_JAVA_ROOT=/usr/lib/$(DEB_HOST_MULTIARCH)/openrtm-$(SHORT_VER)" > $(CURDIR)/debian/openrtm2-java/etc/profile.d/openrtm-java.sh)
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm2-java/usr/bin)
+	(cd $(CURDIR) ; cp examples/rtcd_java $(CURDIR)/debian/openrtm2-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm2-java/usr/bin/rtcd_java)
+	(cd $(CURDIR) ; cp examples/rtcprof_java $(CURDIR)/debian/openrtm2-java/usr/bin ; chmod 755 $(CURDIR)/debian/openrtm2-java/usr/bin/rtcprof_java)
 	
 	# for openrtm-aist-java-example package
-	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java)
-	(cd $(CURDIR) ; cp -R examples/* $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java)
-	(rm -f $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/*.bat)
-	(rm -f $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/*.vbs)
-	(rm -f $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/rtcd_java)
-	(rm -f $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/rtcd_java.sh)
-	(rm -f $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/rtcprof_java*)
-	(chmod 755 $(CURDIR)/debian/openrtm-aist-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/*.sh)
+	(cd $(CURDIR) ; mkdir -p $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java)
+	(cd $(CURDIR) ; cp -R examples/* $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java)
+	(rm -f $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/*.bat)
+	(rm -f $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/*.vbs)
+	(rm -f $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/rtcd_java)
+	(rm -f $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/rtcd_java.sh)
+	(rm -f $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/rtcprof_java*)
+	(chmod 755 $(CURDIR)/debian/openrtm2-java-example/usr/share/openrtm-$(SHORT_VER)/components/java/*.sh)
 
 	dh_install -s
 # Must not depend on anything. This is to be called by

--- a/packages/deb/dpkg_build.sh
+++ b/packages/deb/dpkg_build.sh
@@ -122,7 +122,7 @@ fi
 # package build process
 #------------------------------------------------------------
 packagedir=`pwd`/../../
-rm -f $packagedir/packages/openrtm-aist-java*
+rm -f $packagedir/packages/openrtm2-java*
 
 cp -r debian $packagedir
 


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->
close #92 
## Identify the Bug

Link to #92 


## Description of the Change

- Issueに記載した修正を加えた


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->
- 下記debパッケージの生成を確認
```
openrtm2-java-doc_2.0.0-0_all.deb  openrtm2-java-example_2.0.0-0_amd64.deb  
openrtm2-java_2.0.0-0_amd64.deb
```
- debパッケージでインストールした環境（Ubuntu18.04）で動作確認
- 環境変数の確認
```
$ printenv | grep RTM
RTM_JAVA_ROOT=/usr/lib/x86_64-linux-gnu/openrtm-2.0
```
- マネージャー経由でのRTC起動動作確認
  - rtc.confで下記を定義
  -  rtcd_java -d を実行し、マネージャー経由でJavaとC++の各RTCを起動できることを確認
```
manager.modules.C++.manager_cmd:  rtcd2
manager.modules.C++.profile_cmd: rtcprof2
manager.modules.load_path:
manager.modules.Java.load_paths: /usr/share/openrtm-2.0/components/java/RTMExamples/SimpleIO
manager.modules.C++.load_paths: /usr/share/openrtm-2.0/components/c++/examples/rtc
```

- RTCBuilderで生成したRTCのビルド動作確認
  - ビルド用xmlで、${env.RTM_JAVA_ROOT}を使用している
https://github.com/Nobu19800/testOpenRTM-aist/tree/master/testInPortjava
```
$ cd testInPortjava
$ ant -f build_testInPortjava.xml
$ ls bin/
testInPortjava.class  testInPortjavaComp.class  testInPortjavaImpl.class
$ sh testInPortjava.sh
起動OK！　openrtp2のRTSEにて確認。
```
- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
