### PR TITLE
InPortが正常に動作しない問題の修正

### DIFF
--- a/jp.go.aist.rtm.RTC/src/RTMExamples/SimpleIO/ConsoleOutImpl.java
+++ b/jp.go.aist.rtm.RTC/src/RTMExamples/SimpleIO/ConsoleOutImpl.java
@@ -5,6 +5,7 @@ import java.util.Observable;
 
 import RTC.ReturnCode_t;
 import RTC.TimedLong;
+import RTC.Time;
 import jp.go.aist.rtm.RTC.DataFlowComponentBase;
 import jp.go.aist.rtm.RTC.Manager;
 import jp.go.aist.rtm.RTC.connectorListener.ReturnCode;
@@ -24,6 +25,7 @@ public class ConsoleOutImpl  extends DataFlowComponentBase {
         super(manager);
         // <rtc-template block="initializer">
         m_in_val = new TimedLong();
+        m_in_val.tm = new Time();
         m_in = new DataRef<TimedLong>(m_in_val);
         m_inIn = new InPort<TimedLong>("in", m_in);
         // </rtc-template>

--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPort.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPort.java
@@ -429,8 +429,8 @@ public class InPort<DataType> extends InPortBase {
             ReturnCode ret = ReturnCode.PORT_OK;
             EncapsOutputStreamExt cdr = new EncapsOutputStreamExt(m_orb, 
                                                         isLittleEndian());
-            DataRef<InputStream> dataref 
-                    = new DataRef<InputStream>(cdr.create_input_stream());
+            //DataRef<InputStream> dataref 
+            //        = new DataRef<InputStream>(cdr.create_input_stream());
             synchronized (m_connectors){
 
                 if (m_connectors.size() == 0) {
@@ -440,7 +440,7 @@ public class InPort<DataType> extends InPortBase {
 
                 //ret = m_connectors.elementAt(0).read(dataref);
                 for(int ic=0;ic<m_connectors.size();++ic){
-                    ret = m_connectors.elementAt(ic).read(dataref);
+                    ret = m_connectors.elementAt(ic).read(m_value);
                     if (ret.equals(ReturnCode.PORT_OK)) {
                         break;
                     }
@@ -450,7 +450,7 @@ public class InPort<DataType> extends InPortBase {
             if (ret.equals(ReturnCode.PORT_OK)) {
                 rtcout.println(Logbuf.DEBUG, "data read succeeded");
 
-                m_value.v = read_stream(m_value,dataref.v);
+                //m_value.v = read_stream(m_value,dataref.v);
                 if (m_OnReadConvert != null) {
                     m_value.v = m_OnReadConvert.run(m_value.v);
                     rtcout.println(Logbuf.DEBUG, "OnReadConvert called");

--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPortConnector.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPortConnector.java
@@ -165,7 +165,7 @@ public abstract class InPortConnector extends ConnectorBase {
      * {@.en Reading data}
      *
      */
-    public abstract ReturnCode read(DataRef<InputStream> data);
+    public abstract <DataType> ReturnCode read(DataRef<DataType> data);
     /**
      * {@.ja OutPortのオブジェクトを設定する。}
      * {@.en Sets the object of OutPort}

--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPortPullConnector.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPortPullConnector.java
@@ -158,7 +158,7 @@ public class InPortPullConnector extends InPortConnector {
      *         PRECONDITION_NOT_MET Preconditin not met
      *         PORT_ERROR           Other error}
      */
-    public ReturnCode read(DataRef<InputStream> data){
+    public <DataType> ReturnCode read(DataRef<DataType> data){
         rtcout.println(Logbuf.TRACE, "InPortPullConnector.read()");
         if (m_directOutPort != null) {
             return ReturnCode.BUFFER_EMPTY;

--- a/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPortPushConnector.java
+++ b/jp.go.aist.rtm.RTC/src/jp/go/aist/rtm/RTC/port/InPortPushConnector.java
@@ -128,7 +128,7 @@ public class InPortPushConnector extends InPortConnector {
      *         PORT_ERROR           Other error}
      *
      */
-    public ReturnCode read(DataRef<InputStream> data) {
+    public <DataType> ReturnCode read(DataRef<DataType> data) {
         rtcout.println(Logbuf.TRACE, "read()");
         if (m_directOutPort != null) {
             OutPort outport = (OutPort)m_directOutPort;
@@ -164,7 +164,7 @@ public class InPortPushConnector extends InPortConnector {
 */
         if(ret != jp.go.aist.rtm.RTC.buffer.ReturnCode.BUFFER_OK){
             ReturnCode code = convertReturn(ret,dataref);
-            data.v = dataref.v.create_input_stream();
+            //data.v = dataref.v.create_input_stream();
             return code;
         }
         else {
@@ -176,7 +176,8 @@ public class InPortPushConnector extends InPortConnector {
             m_serializer.isLittleEndian(m_isLittleEndian);
             //InputStream in_cdr = cdr.create_input_stream();
             //SerializeReturnCode ser_ret = m_serializer.deserialize(dataref,in_cdr);
-            SerializeReturnCode ser_ret = m_serializer.deserialize(dataref,cdr);
+
+            SerializeReturnCode ser_ret = m_serializer.deserialize(data,dataref.v);
 
             if(ser_ret.equals(SerializeReturnCode.SERIALIZE_OK)){
                 //data = _data;


### PR DESCRIPTION
<!--
* Fill out the template below.  
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution.
-->

## Identify the Bug

OutPortからInPortにデータを送信した場合に、read関数呼び出し時に例外が発生しエラー状態になる。


## Description of the Change

InPortのread関数内でInPortPushConnectorのread関数を呼んでデシリアライズ前のデータを受け取るという処理をしたいという意図だと推測しているが、InPortPushConnectorのread関数がリングバッファからデータを読み込んでもInPort側に渡さないため、空のデータをシリアライズしようとして例外が発生している。

そもそもInPortPushConnectorのread関数でデシリアライズする処理が想定しているものなので、取り急ぎInPortPushConnectorのread関数でデシリアライズしてデータをInPortに渡すように修正した。

また、ソースコードを見た限りでは、以下の問題点がある。

- InPortPushConnectorのデシリアライズはCORBA_CdrSerializerのdeserialize関数を呼んでいるが、ConnecterDataListenerでのデシリアライズは、cdrのデシリアライズの処理をそのまま書いているため、実質的にcdrシリアライザ以外は選択不可能
- Pull型通信の挙動がおかしい。read関数実行時に、OutPort側にデータが無くてもON_BUFFER_WRITE、ON_RECEIVEDコールバック関数が呼ばれる。


## Verification 

<!--
Verify that the change has not introduced any regressions.   
Check the item below and fill the checkbox.
You can fill checkbox by using the [X].
If this request do not need to build and tests, delete the items and specify that these are no need.
-->

- [x] Did you succeed the build?  
- [x] No warnings for the build?  
- [ ] Have you passed the unit tests?  
